### PR TITLE
Add support for intergers in bindValues

### DIFF
--- a/src/Oci8/Oci8Connection.php
+++ b/src/Oci8/Oci8Connection.php
@@ -498,7 +498,11 @@ class Oci8Connection extends Connection
     public function bindValues($statement, $bindings)
     {
         foreach ($bindings as $key => $value) {
-            $statement->bindValue(is_string($key) ? $key : $key + 1, $value);
+            $statement->bindValue(
+                is_string($key) ? $key : $key + 1,
+                $value,
+                is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+            );
         }
     }
 }


### PR DESCRIPTION
When binding paramters integers get bound as strings which cause and oracle ORA-00932: inconsistent datatypes: expected CHAR got NUMBER when working with query builder.

